### PR TITLE
 add tooltip component with adjustable position and fade animation

### DIFF
--- a/tooltip.html
+++ b/tooltip.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Tooltip Demo</title>
+  <style>
+    body {
+      display: grid;
+      place-items: center;
+      height: 100vh;
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, Arial;
+      background: #f8fafc;
+      margin: 0;
+    }
+
+    /* Tooltip container */
+    .tooltip-container {
+      position: relative;
+      display: inline-block;
+      margin: 20px;
+    }
+
+    /* Tooltip text */
+    .tooltip-text {
+      position: absolute;
+      padding: 6px 10px;
+      background: rgba(37, 99, 235, 0.9); /* blue */
+      color: white;
+      font-size: 14px;
+      border-radius: 4px;
+      white-space: nowrap;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.3s ease;
+      z-index: 1000;
+    }
+
+    /* Show tooltip on hover */
+    .tooltip-container:hover .tooltip-text {
+      opacity: 1;
+    }
+
+    /* Position variants */
+    .tooltip-top { bottom: 100%; left: 50%; transform: translateX(-50%) translateY(-8px); }
+    .tooltip-bottom { top: 100%; left: 50%; transform: translateX(-50%) translateY(8px); }
+    .tooltip-left { right: 100%; top: 50%; transform: translateX(-8px) translateY(-50%); }
+    .tooltip-right { left: 100%; top: 50%; transform: translateX(8px) translateY(-50%); }
+
+    /* Optional: small arrow */
+    .tooltip-text::after {
+      content: '';
+      position: absolute;
+      border-style: solid;
+    }
+    .tooltip-top::after {
+      top: 100%; left: 50%;
+      border-width: 5px 5px 0 5px;
+      border-color: rgba(37, 99, 235, 0.9) transparent transparent transparent;
+      transform: translateX(-50%);
+    }
+    .tooltip-bottom::after {
+      bottom: 100%; left: 50%;
+      border-width: 0 5px 5px 5px;
+      border-color: transparent transparent rgba(37, 99, 235, 0.9) transparent;
+      transform: translateX(-50%);
+    }
+    .tooltip-left::after {
+      left: 100%; top: 50%;
+      border-width: 5px 0 5px 5px;
+      border-color: transparent transparent transparent rgba(37, 99, 235, 0.9);
+      transform: translateY(-50%);
+    }
+    .tooltip-right::after {
+      right: 100%; top: 50%;
+      border-width: 5px 5px 5px 0;
+      border-color: transparent rgba(37, 99, 235, 0.9) transparent transparent;
+      transform: translateY(-50%);
+    }
+  </style>
+</head>
+<body>
+  <div class="tooltip-container">
+    <button>Hover me (top)</button>
+    <span class="tooltip-text tooltip-top">Tooltip on top</span>
+  </div>
+
+  <div class="tooltip-container">
+    <button>Hover me (bottom)</button>
+    <span class="tooltip-text tooltip-bottom">Tooltip on bottom</span>
+  </div>
+
+  <div class="tooltip-container">
+    <button>Hover me (left)</button>
+    <span class="tooltip-text tooltip-left">Tooltip on left</span>
+  </div>
+
+  <div class="tooltip-container">
+    <button>Hover me (right)</button>
+    <span class="tooltip-text tooltip-right">Tooltip on right</span>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
feat: add tooltip component with adjustable position and fade animation

Added a standalone tooltip component that shows on hover.
Features:
- Position variants: top, bottom, left, right
- Smooth fade-in/out animation using CSS transitions
- Optional small arrow pointing to target
- Fully standalone single-file HTML implementation

File added: `tooltip.html`

How to test:
1. Open `tooltip.html` in a browser.
2. Hover over each button to see the tooltip appear at different positions.

This addresses issue #4  (Add a tooltip that appears when hovering over a specific element).
